### PR TITLE
refactor: Re-using a single PrismaClient instance

### DIFF
--- a/src/v1/clients/prisma.ts
+++ b/src/v1/clients/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/src/v1/controllers/users.controller.ts
+++ b/src/v1/controllers/users.controller.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../clients/prisma";
 import "express-async-errors";
-
-const prisma = new PrismaClient();
 
 export const getUsers = async (_: Request, res: Response) => {
   const users = await prisma.users.findMany();


### PR DESCRIPTION
Refactored to reuse single PrismaClient instance as per official documentation. https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#prismaclient-in-long-running-applications