### PR TITLE
docs: Fix capitalization of TypeScript in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# REST API using Node.js, Express, and Typescript
+# REST API using Node.js, Express, and TypeScript
 
 Sample REST API developed using Node.js, Express, and TypeScript.
 


### PR DESCRIPTION
Fix capitalization of TypeScript in README.